### PR TITLE
Fix AWSSDK v4 compatibility: SQS client removes EndpointResolver from…

### DIFF
--- a/AWSXRay.SQS.Publisher.Extensions/AWSXRay.SQS.Publisher.Extensions.csproj
+++ b/AWSXRay.SQS.Publisher.Extensions/AWSXRay.SQS.Publisher.Extensions.csproj
@@ -1,21 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <Version>2.0.0</Version>
     <Authors>Will Axtell</Authors>
     <Description>AWS XRay pipeline handler that will proliferate the XRay TraceHeader across SendMessage and SendMessageBatch calls.</Description>
     <PackageProjectUrl>https://github.com/waxtell/AWSXRay.SQS.Publisher.Extensions</PackageProjectUrl>
     <RepositoryUrl>https://github.com/waxtell/AWSXRay.SQS.Publisher.Extensions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>AWS XRay SQS TraceHeader</PackageTags>
-    <PackageReleaseNotes>1.0.1- Target earlier version of AWSSDK.Core
+    <PackageReleaseNotes>2.0.0- Update AWSSDK dependencies for v4 compatibility
+1.0.1- Target earlier version of AWSSDK.Core
 1.0.0- Initial release</PackageReleaseNotes>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="AWSSDK.SQS" Version="3.3.102.23" />
     <PackageReference Include="AWSXRayRecorder.Core" Version="2.6.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.18" />
+    <PackageReference Include="AWSXRayRecorder.Core" Version="2.13.0" />
   </ItemGroup>
 
 </Project>

--- a/AWSXRay.SQS.Publisher.Extensions/SQSXRayPipelineCustomizer.cs
+++ b/AWSXRay.SQS.Publisher.Extensions/SQSXRayPipelineCustomizer.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using Amazon.Runtime.Internal;
+using Amazon.SQS;
+#if NET8_0_OR_GREATER
+using Amazon.SQS.Internal;
+#endif
 
 namespace AWSXRay.SQS.Publisher.Extensions
 {
@@ -7,10 +11,18 @@ namespace AWSXRay.SQS.Publisher.Extensions
     internal class SQSXRayPipelineCustomizer : IRuntimePipelineCustomizer
     {
         public string UniqueName => typeof(SQSXRayPipelineCustomizer).FullName;
-   
+
         public void Customize(Type serviceClientType, RuntimePipeline pipeline)
         {
+            if (!typeof(AmazonSQSClient).IsAssignableFrom(serviceClientType))
+                return;
+
+#if NET8_0_OR_GREATER
+            // AWSSDK.SQS v4 removes EndpointResolver and replaces it with AmazonSQSEndpointResolver
+            pipeline.AddHandlerAfter<AmazonSQSEndpointResolver>(new SQSXRayPipelineHandler());
+#else
             pipeline.AddHandlerAfter<EndpointResolver>(new SQSXRayPipelineHandler());
+#endif
         }
    }
 }


### PR DESCRIPTION
… pipeline

AWSSDK.SQS v4 replaces EndpointResolver with AmazonSQSEndpointResolver in CustomizeRuntimePipeline, which runs before ApplyCustomizations. This causes AddHandlerAfter<EndpointResolver> to throw InvalidOperationException at runtime.

- Add net8.0 target with AWSSDK.SQS 4.x and AWSXRayRecorder.Core 2.13.0
- Use AddHandlerAfter<AmazonSQSEndpointResolver> on net8.0
- Guard customizer to only apply for AmazonSQSClient types
- Preserve v3 SDK behavior for netstandard targets